### PR TITLE
Replace current 'energy' with 'power' (Watts)

### DIFF
--- a/custom_components/tapo/sensor.py
+++ b/custom_components/tapo/sensor.py
@@ -13,7 +13,7 @@ from custom_components.tapo.const import (
     SUPPORTED_DEVICE_AS_SWITCH_POWER_MONITOR,
 )
 
-### Supported sensors: Today energy and current energy
+### Supported sensors: Today energy and current power
 SUPPORTED_SENSOR = [
     TapoTodayEnergySensor,
     TapoMonthEnergySensor,

--- a/custom_components/tapo/tapo_sensor_entity.py
+++ b/custom_components/tapo/tapo_sensor_entity.py
@@ -121,7 +121,7 @@ class TapoCurrentEnergySensor(TapoSensor):
         super().__init__(
             coordiantor,
             SensorConfig(
-                "current energy",
+                "current power",
                 DEVICE_CLASS_POWER,
                 STATE_CLASS_MEASUREMENT,
                 POWER_WATT,


### PR DESCRIPTION
First of all I would like to take the opportunity to thank you for the great job done here.

This is a small PR to change "Current _energy_" to "Current **power**" since the measure is actually related to power (in Watts) instead of energy (Wh) which is indeed not an instantaneous measure as power is, but a counter.

This change is not backward compatible (so old entity will go away and a new one will be installed), so I will let the maintainer to decide what to do.

![image](https://user-images.githubusercontent.com/1818657/202923254-d3fb90bf-5d63-45bc-b974-866bfc9fd3cc.png)
