### PR TITLE
Prevent error when adding first tapo component

### DIFF
--- a/custom_components/tapo/config_flow.py
+++ b/custom_components/tapo/config_flow.py
@@ -61,6 +61,7 @@ class TapoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             unique_id = unique_data["unique_id"]
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()
+            self.hass.data.setdefault(DOMAIN, {})
             self.hass.data[DOMAIN][f"{unique_id}_api"] = api
         except InvalidAuth as error:
             errors["base"] = "invalid_auth"


### PR DESCRIPTION
Unexpected error when adding first Tapo integration to Home Assistant.

This appears to be because the dictionary key does not exist `self.hass.data['tapo']`
Therefore, add a line which will initialize it, if it does not exist.

I am not sure, but sounds similar to:
#314 