### PR TITLE
fix: hub/sensor.py type checks

### DIFF
--- a/custom_components/tapo/hub/sensor.py
+++ b/custom_components/tapo/hub/sensor.py
@@ -1,5 +1,4 @@
-import datetime
-from datetime import date
+from datetime import date, datetime
 from typing import cast
 from typing import Optional
 from typing import Union


### PR DESCRIPTION
datetime was a module, not a type; fix the import.