### PR TITLE
Fix error adding entities

### DIFF
--- a/custom_components/tapo/coordinators.py
+++ b/custom_components/tapo/coordinators.py
@@ -32,13 +32,13 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from plugp100.api.hub.hub_device import HubDevice
 from plugp100.api.ledstrip_device import LedStripDevice
 from plugp100.api.light_device import LightDevice
-from plugp100.api.plug_device import EnergyInfo
 from plugp100.api.plug_device import PlugDevice
-from plugp100.api.plug_device import PowerInfo
 from plugp100.api.power_strip_device import PowerStripDevice
 from plugp100.api.tapo_client import TapoClient
 from plugp100.common.functional.tri import Failure
 from plugp100.common.functional.tri import Try
+from plugp100.responses.energy_info import EnergyInfo
+from plugp100.responses.power_info import PowerInfo
 from plugp100.responses.child_device_list import PowerStripChild
 from plugp100.responses.device_state import DeviceInfo as TapoDeviceInfo
 from plugp100.responses.device_state import LedStripDeviceState

--- a/custom_components/tapo/sensors/__init__.py
+++ b/custom_components/tapo/sensors/__init__.py
@@ -107,7 +107,11 @@ class TodayRuntimeSensorSource(TapoSensorSource):
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:
-        return coordinator.get_state_of(EnergyInfo).today_runtime
+        if coordinator.has_capability(EnergyInfo):
+            sensor = coordinator.get_state_of(EnergyInfo)
+            if sensor is not None:
+                return sensor.today_runtime
+        return None
 
 
 class MonthRuntimeSensorSource(TapoSensorSource):
@@ -120,4 +124,8 @@ class MonthRuntimeSensorSource(TapoSensorSource):
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:
-        return coordinator.get_state_of(EnergyInfo).month_runtime
+        if coordinator.has_capability(EnergyInfo):
+            sensor = coordinator.get_state_of(EnergyInfo)
+            if sensor is not None:
+                return sensor.month_runtime
+        return None

--- a/custom_components/tapo/sensors/__init__.py
+++ b/custom_components/tapo/sensors/__init__.py
@@ -13,8 +13,8 @@ from homeassistant.const import POWER_WATT
 from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 from homeassistant.const import TIME_MINUTES
 from homeassistant.helpers.typing import StateType
-from plugp100.api.plug_device import EnergyInfo
-from plugp100.api.plug_device import PowerInfo
+from plugp100.responses.energy_info import EnergyInfo
+from plugp100.responses.power_info import PowerInfo
 from plugp100.responses.device_state import DeviceInfo
 
 


### PR DESCRIPTION
Current HA Core ： 2023.11.3
Current Firmware：1.0.7 Build 230801 Rel.091142
TC version: v.2.11.0

After the latest update my P125m plug stopped working. The relevant logs are below.

This pull request updates `sensors/__init__.py` to check if a sensor has a capability before accessing its property.

This patch should fix #626.

Let me know if you need anything further; and thanks for all your efforts.

`2023-11-30 09:17:36.921 ERROR (MainThread) [homeassistant.components.sensor] Error adding entities for domain sensor with platform tapo
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 752, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1023, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 743, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 843, in _async_write_ha_state
    state, attr = self._async_generate_attributes()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 784, in _async_generate_attributes
    state = self._stringify_state(available)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 749, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 501, in state
    value = self.native_value
            ^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tapo/sensor.py", line 111, in native_value
    return self._sensor_source.get_value(self.coordinator)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tapo/sensors/__init__.py", line 110, in get_value
    return coordinator.get_state_of(EnergyInfo).today_runtime`