### PR TITLE
fix deprication warning for 2024.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The core of the integration is provied by [plugp100](https://github.com/petretia
 [![License][license-shield]](LICENSE)
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
+Please help me to complete the [new roadmap](https://github.com/petretiandrea/home-assistant-tapo-p100/discussions/655)
+
 ## Warnings
 
 ### Tapo protocol

--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -17,13 +17,22 @@ from custom_components.tapo.helpers import hass_to_tapo_color_temperature
 from custom_components.tapo.helpers import tapo_to_hass_brightness
 from custom_components.tapo.helpers import tapo_to_hass_color_temperature
 from custom_components.tapo.setup_helpers import setup_from_platform_config
-from homeassistant.components.light import ATTR_BRIGHTNESS
-from homeassistant.components.light import ATTR_COLOR_TEMP
-from homeassistant.components.light import ATTR_EFFECT
-from homeassistant.components.light import ATTR_HS_COLOR
-from homeassistant.components.light import ColorMode
-from homeassistant.components.light import LightEntity
-from homeassistant.components.light import SUPPORT_EFFECT
+# from homeassistant.components.light import ATTR_BRIGHTNESS
+# from homeassistant.components.light import ATTR_COLOR_TEMP
+# from homeassistant.components.light import ATTR_EFFECT
+# from homeassistant.components.light import ATTR_HS_COLOR
+# from homeassistant.components.light import ColorMode
+# from homeassistant.components.light import LightEntity
+# from homeassistant.components.light import SUPPORT_EFFECT
+from homeassistant.components.light (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
+    ATTR_EFFECT,
+    ATTR_HS_COLOR,
+    ColorMode,
+    LightEntity,
+    LightEntityFeature,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -82,7 +91,8 @@ class TapoLight(BaseTapoEntity[LightTapoCoordinator], LightEntity):
         self._attr_min_color_temp_kelvin = 2500
         self._attr_max_mireds = kelvin_to_mired(self._attr_min_color_temp_kelvin)
         self._attr_min_mireds = kelvin_to_mired(self._attr_max_color_temp_kelvin)
-        self._attr_supported_features = SUPPORT_EFFECT if self._effects else 0
+        # self._attr_supported_features = SUPPORT_EFFECT if self._effects else 0
+        self._attr_supported_features = LightEntityFeature.EFFECT if self._effects else 0
         self._attr_supported_color_modes = color_modes
         self._attr_effect_list = list(self._effects.keys()) if self._effects else None
 

--- a/custom_components/tapo/sensors/__init__.py
+++ b/custom_components/tapo/sensors/__init__.py
@@ -1,17 +1,25 @@
 from custom_components.tapo.coordinators import TapoCoordinator
 from custom_components.tapo.sensors.sensor_config import SensorConfig
 from custom_components.tapo.sensors.tapo_sensor_source import TapoSensorSource
-from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.components.sensor import SensorStateClass
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
-from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
-from homeassistant.const import DEVICE_CLASS_ENERGY
-from homeassistant.const import DEVICE_CLASS_POWER
-from homeassistant.const import DEVICE_CLASS_SIGNAL_STRENGTH
-from homeassistant.const import ENERGY_KILO_WATT_HOUR
-from homeassistant.const import POWER_WATT
-from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
-from homeassistant.const import TIME_MINUTES
+# from homeassistant.components.sensor import SensorDeviceClass
+# from homeassistant.components.sensor import SensorStateClass
+# from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
+# from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
+# from homeassistant.const import DEVICE_CLASS_ENERGY
+# from homeassistant.const import DEVICE_CLASS_POWER
+# from homeassistant.const import DEVICE_CLASS_SIGNAL_STRENGTH
+# from homeassistant.const import ENERGY_KILO_WATT_HOUR
+# from homeassistant.const import POWER_WATT
+# from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+# from homeassistant.const import TIME_MINUTES
+from homeassistant.const import (
+  SensorDeviceClass,
+  SensorStateClass,
+  UnitOfEnergy,
+  UnitOfPower,
+  UnitOfTime,
+  SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+)
 from homeassistant.helpers.typing import StateType
 from plugp100.responses.energy_info import EnergyInfo
 from plugp100.responses.power_info import PowerInfo
@@ -22,9 +30,12 @@ class TodayEnergySensorSource(TapoSensorSource):
     def get_config(self) -> SensorConfig:
         return SensorConfig(
             "today energy",
-            DEVICE_CLASS_ENERGY,
-            STATE_CLASS_TOTAL_INCREASING,
-            ENERGY_KILO_WATT_HOUR,
+            SensorDeviceClass.ENERGY,
+            SensorStateClass.TOTAL_INCREASING,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            # DEVICE_CLASS_ENERGY,
+            # STATE_CLASS_TOTAL_INCREASING,
+            # ENERGY_KILO_WATT_HOUR,
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:
@@ -37,9 +48,12 @@ class MonthEnergySensorSource(TapoSensorSource):
     def get_config(self) -> SensorConfig:
         return SensorConfig(
             "month energy",
-            DEVICE_CLASS_ENERGY,
-            STATE_CLASS_TOTAL_INCREASING,
-            ENERGY_KILO_WATT_HOUR,
+            SensorDeviceClass.ENERGY,
+            SensorStateClass.TOTAL_INCREASING,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            # DEVICE_CLASS_ENERGY,
+            # STATE_CLASS_TOTAL_INCREASING,
+            # ENERGY_KILO_WATT_HOUR,
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:
@@ -67,9 +81,12 @@ class CurrentEnergySensorSource(TapoSensorSource):
     def get_config(self) -> SensorConfig:
         return SensorConfig(
             "current power",
-            DEVICE_CLASS_POWER,
-            STATE_CLASS_MEASUREMENT,
-            POWER_WATT,
+            SensorDeviceClass.POWER,
+            SensorStateClass.MEASUREMENT,
+            UnitOfPower.WATT,
+            # DEVICE_CLASS_POWER,
+            # STATE_CLASS_MEASUREMENT,
+            # POWER_WATT,
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:
@@ -84,7 +101,8 @@ class SignalSensorSource(TapoSensorSource):
     def get_config(self) -> SensorConfig:
         return SensorConfig(
             name="signal level",
-            device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+            # device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
             state_class=None,
             unit_measure=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
             is_diagnostic=True,
@@ -103,7 +121,8 @@ class TodayRuntimeSensorSource(TapoSensorSource):
             "today runtime",
             SensorDeviceClass.DURATION,
             SensorStateClass.TOTAL_INCREASING,
-            TIME_MINUTES,
+            UnitOfTime.MINUTES,
+            # TIME_MINUTES,
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:
@@ -120,7 +139,8 @@ class MonthRuntimeSensorSource(TapoSensorSource):
             "month runtime",
             SensorDeviceClass.DURATION,
             SensorStateClass.TOTAL_INCREASING,
-            TIME_MINUTES,
+            UnitOfTime.MINUTES,
+            # TIME_MINUTES,
         )
 
     def get_value(self, coordinator: TapoCoordinator) -> StateType:

--- a/custom_components/tapo/sensors/__init__.py
+++ b/custom_components/tapo/sensors/__init__.py
@@ -5,6 +5,10 @@ from custom_components.tapo.sensors.tapo_sensor_source import TapoSensorSource
 # from homeassistant.components.sensor import SensorStateClass
 # from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
 # from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
+from homeassistant.components.sensor import (
+  SensorDeviceClass,
+  SensorStateClass,
+)
 # from homeassistant.const import DEVICE_CLASS_ENERGY
 # from homeassistant.const import DEVICE_CLASS_POWER
 # from homeassistant.const import DEVICE_CLASS_SIGNAL_STRENGTH
@@ -13,8 +17,6 @@ from custom_components.tapo.sensors.tapo_sensor_source import TapoSensorSource
 # from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 # from homeassistant.const import TIME_MINUTES
 from homeassistant.const import (
-  SensorDeviceClass,
-  SensorStateClass,
   UnitOfEnergy,
   UnitOfPower,
   UnitOfTime,


### PR DESCRIPTION
This should address the deprication warnings HA 2024.1 will raise.
Also, I've combined the `import from homeassistant.xxx` ... 

( #662 )

Pls. test this before merging, because I can't - I don't have Tapo devices in use.