### PR TITLE
Light: Add hs null check to avoid crash

### DIFF
--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -81,6 +81,9 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
 
     @property
     def hs_color(self):
+        if self.device.hs is None:
+            return None
+
         (hue, saturation) = (self.device.hs.hue, self.device.hs.saturation)
         color_temp = self.device.color_temp
         if (


### PR DESCRIPTION
Avoid a crash on the hs light check if none is set.

Fixes #746