### PR TITLE
check empty energy_info to avoid error

### DIFF
--- a/custom_components/tapo/sensors/__init__.py
+++ b/custom_components/tapo/sensors/__init__.py
@@ -23,7 +23,7 @@ class TodayEnergySensorSource(TapoSensorSource):
 
     def get_value(self, coordinator: TapoDataCoordinator) -> StateType:
         if energy := coordinator.device.get_component(EnergyComponent):
-            return energy.energy_info.today_energy / 1000
+            return energy.energy_info.today_energy / 1000 if energy.energy_info else None
         return None
 
 
@@ -38,7 +38,7 @@ class MonthEnergySensorSource(TapoSensorSource):
 
     def get_value(self, coordinator: TapoDataCoordinator) -> StateType:
         if energy := coordinator.device.get_component(EnergyComponent):
-            return energy.energy_info.month_energy / 1000
+            return energy.energy_info.month_energy / 1000 if energy.energy_info else None
         return None
 
 


### PR DESCRIPTION
I have two P110, and the first one was not working after I added the second one.
Based on the log, the energy_info is None when startup, so, the following entities are all failed to load.
And from the Tapo app, the energy info is shown as "--" in the first P110 as well.

After I have added the Null check, there is no startup error and the first P110 is now working (at least can be turned on/off via HA)
Although the energy_info is still empty in HA, it is the same result as Tapo app.