### PR TITLE
fix: Return LightEntityFeature(0) zero value in supported_features when there are no effects

### DIFF
--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -52,7 +52,7 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
         self._attr_max_mireds = kelvin_to_mired(self._attr_min_color_temp_kelvin)
         self._attr_min_mireds = kelvin_to_mired(self._attr_max_color_temp_kelvin)
         self._attr_supported_features = (
-            LightEntityFeature.EFFECT if self._effects else 0
+            LightEntityFeature.EFFECT if self._effects else LightEntityFeature(0)
         )
         self._attr_supported_color_modes = _components_to_color_modes(device)
         self._attr_effect_list = list(self._effects.keys()) if self._effects else None


### PR DESCRIPTION
Fixes https://github.com/petretiandrea/home-assistant-tapo-p100/issues/825

In HA 2025.1 support for using integers in `supported_features` was removed https://github.com/home-assistant/core/pull/132371