### PR TITLE
fix: correct supported features type in Tapo light entity

### DIFF
--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -52,7 +52,7 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
         self._attr_max_mireds = kelvin_to_mired(self._attr_min_color_temp_kelvin)
         self._attr_min_mireds = kelvin_to_mired(self._attr_max_color_temp_kelvin)
         self._attr_supported_features = (
-            LightEntityFeature.EFFECT if self._effects else 0
+            {LightEntityFeature.EFFECT} if self._effects else set()
         )
         self._attr_supported_color_modes = _components_to_color_modes(device)
         self._attr_effect_list = list(self._effects.keys()) if self._effects else None


### PR DESCRIPTION
This pull request fixes a TypeError occurring when Home Assistant expects `supported_features` to be iterable, but receives an integer instead. The issue has been resolved by ensuring that `supported_features` is always a set, even when no effects are supported.

I had the same issue as is #825, but I'm owner of Light Bulb L510, so for some reasons code changes from PR #826 didn't work for me, after more tweaking I come to this solution.

Tested with Home Assistant version:
* Core: 2025.1.0
* Supervisor: 2024.12.3
* Operating System: 14.1
* User Interface: 20250103.0

Light Bulb: Tapo L510 Series (software 1.3.1)