### PR TITLE
fix: mired deprecated

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -20,8 +20,6 @@ scene:
       light.striscia_luminosa_smart:
         min_color_temp_kelvin: 2500
         max_color_temp_kelvin: 6500
-        min_mireds: 153
-        max_mireds: 400
         effect_list:
           - bubblingcauldron
           - aurora
@@ -70,8 +68,6 @@ scene:
       light.striscia_luminosa_smart:
         min_color_temp_kelvin: 2500
         max_color_temp_kelvin: 6500
-        min_mireds: 153
-        max_mireds: 400
         effect_list:
           - bubblingcauldron
           - aurora
@@ -122,8 +118,6 @@ scene:
       light.striscia_luminosa_smart:
         min_color_temp_kelvin: 2500
         max_color_temp_kelvin: 6500
-        min_mireds: 153
-        max_mireds: 400
         effect_list:
           - bubblingcauldron
           - aurora

--- a/custom_components/tapo/helpers.py
+++ b/custom_components/tapo/helpers.py
@@ -4,12 +4,6 @@ from typing import TypeVar
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from homeassistant.util.color import (
-    color_temperature_kelvin_to_mired as kelvin_to_mired,
-)
-from homeassistant.util.color import (
-    color_temperature_mired_to_kelvin as mired_to_kelvin,
-)
 from plugp100.common.functional.tri import Try
 from plugp100.responses.tapo_exception import TapoException, TapoError
 
@@ -39,15 +33,13 @@ def tapo_to_hass_brightness(brightness: float | None) -> float | None:
         return round((brightness * 255) / 100)
     return brightness
 
-
-# Mireds and Kelving are min, max tuple
 def hass_to_tapo_color_temperature(
-        color_temp: int | None, mireds: (int, int), kelvin: (int, int)
+        color_temp: int | None, kelvin: (int, int)
 ) -> int | None:
     if color_temp is not None:
-        constraint_color_temp = clamp(color_temp, mireds[0], mireds[1])
+        constraint_color_temp = clamp(color_temp, kelvin[0], kelvin[1])
         return clamp(
-            mired_to_kelvin(constraint_color_temp),
+            constraint_color_temp,
             min_value=kelvin[0],
             max_value=kelvin[1],
         )
@@ -55,13 +47,13 @@ def hass_to_tapo_color_temperature(
 
 
 def tapo_to_hass_color_temperature(
-        color_temp: int | None, mireds: (int, int)
+        color_temp: int | None, colors: (int, int)
 ) -> int | None:
     if color_temp is not None and color_temp > 0:
         return clamp(
-            kelvin_to_mired(color_temp),
-            min_value=mireds[0],
-            max_value=mireds[1],
+            color_temp,
+            min_value=colors[0],
+            max_value=colors[1],
         )
     return None
 

--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -12,9 +12,6 @@ from homeassistant.components.light import LightEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.color import (
-    color_temperature_kelvin_to_mired as kelvin_to_mired,
-)
 from plugp100.api.light_effect_preset import LightEffectPreset
 from plugp100.new.components.light_effect_component import LightEffectComponent
 from plugp100.new.tapobulb import TapoBulb
@@ -49,8 +46,6 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
         # set homeassistant light entity attributes
         self._attr_max_color_temp_kelvin = 6500
         self._attr_min_color_temp_kelvin = 2500
-        self._attr_max_mireds = kelvin_to_mired(self._attr_min_color_temp_kelvin)
-        self._attr_min_mireds = kelvin_to_mired(self._attr_max_color_temp_kelvin)
         self._attr_supported_features = (
             LightEntityFeature.EFFECT if self._effects else LightEntityFeature(0)
         )
@@ -95,7 +90,7 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
     @property
     def color_temp(self):
         return tapo_to_hass_color_temperature(
-            self.device.color_temp, (self.min_mireds, self.max_mireds)
+            self.device.color_temp, (self.min_color_temp_kelvin, self.max_color_temp_kelvin)
         )
 
     @property
@@ -114,7 +109,6 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
         tapo_brightness = hass_to_tapo_brightness(brightness)
         tapo_color_temp = hass_to_tapo_color_temperature(
             color_temp,
-            (self.min_mireds, self.max_mireds),
             (self.min_color_temp_kelvin, self.max_color_temp_kelvin),
         )
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -10,9 +10,7 @@ from homeassistant.components.light import ATTR_EFFECT
 from homeassistant.components.light import ATTR_EFFECT_LIST
 from homeassistant.components.light import ATTR_HS_COLOR
 from homeassistant.components.light import ATTR_MAX_COLOR_TEMP_KELVIN
-from homeassistant.components.light import ATTR_MAX_MIREDS
 from homeassistant.components.light import ATTR_MIN_COLOR_TEMP_KELVIN
-from homeassistant.components.light import ATTR_MIN_MIREDS
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES
 from homeassistant.components.light import ColorMode
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
@@ -42,8 +40,6 @@ async def test_light_color_state(hass: HomeAssistant, tapo_device: MagicMock):
     assert state_entity.attributes[ATTR_BRIGHTNESS] == 255  # means 100 on tapo
     assert state_entity.attributes[ATTR_COLOR_TEMP] == 154  # is merids, means 6493K
     assert state_entity.attributes[ATTR_COLOR_TEMP_KELVIN] == 6493
-    assert state_entity.attributes[ATTR_MAX_MIREDS] == 400
-    assert state_entity.attributes[ATTR_MIN_MIREDS] == 153
     assert state_entity.attributes[ATTR_MAX_COLOR_TEMP_KELVIN] == 6500
     assert state_entity.attributes[ATTR_MIN_COLOR_TEMP_KELVIN] == 2500
     assert state_entity.attributes[ATTR_HS_COLOR] == (48.348, 2.014)


### PR DESCRIPTION
Fixes #935.

Remove the light entity state attributes `color_temp`, `kelvin`, `min_mireds`, and `max_mireds` as they have been removed in 2026.3 - [source](https://www.home-assistant.io/blog/2026/03/04/release-20263/).