### PR TITLE
fix(core): align tapo lights with kelvin-only api

### DIFF
--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -62,7 +62,7 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
             return ColorMode.HS
         elif (
             ColorMode.COLOR_TEMP in self.supported_color_modes
-            and self.color_temp is not None
+            and self.color_temp_kelvin is not None
         ):
             return ColorMode.COLOR_TEMP
         elif (
@@ -97,15 +97,11 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
                 return hue, saturation
 
     @property
-    def color_temp(self):
+    def color_temp_kelvin(self):
         return tapo_to_hass_color_temperature(
             self.device.color_temp,
             (self.min_color_temp_kelvin, self.max_color_temp_kelvin),
         )
-
-    @property
-    def color_temp_kelvin(self):
-        return self.device.color_temp
 
     @property
     def effect(self) -> Optional[str]:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -83,6 +83,23 @@ async def test_light_color_service_call(hass: HomeAssistant, tapo_device: MagicM
     tapo_device.set_color_temperature.assert_not_called()
 
 
+@pytest.mark.parametrize("tapo_device", [mock_bulb(), mock_led_strip()])
+async def test_light_turn_on_without_attributes(
+    hass: HomeAssistant, tapo_device: MagicMock
+):
+    await setup_platform(hass, tapo_device, [LIGHT_DOMAIN])
+    entity_id = await extract_entity_id(tapo_device, LIGHT_DOMAIN)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    tapo_device.turn_on.assert_called()
+
+
 @pytest.mark.parametrize("tapo_device", [mock_led_strip()])
 async def test_light_color_effects(hass: HomeAssistant, tapo_device: MagicMock):
     await setup_platform(hass, tapo_device, [LIGHT_DOMAIN])


### PR DESCRIPTION
## Summary
- stop relying on the removed legacy `color_temp` light property
- use the Kelvin-based light API consistently for color temperature detection
- add a regression test for `light.turn_on` without extra attributes

Closes #942.

## Testing
- `python3 -m py_compile custom_components/tapo/light.py tests/test_light.py`
- `uv run pytest -q tests/test_light.py`
- `uv run pytest -q`
