### PR TITLE
fix(core): avoid invalid hs payloads for led strips

### DIFF
--- a/custom_components/tapo/light.py
+++ b/custom_components/tapo/light.py
@@ -14,6 +14,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugp100.api.light_effect_preset import LightEffectPreset
+from plugp100.api.requests.set_device_info.set_light_color_info_params import (
+    LightColorDeviceInfoParams,
+)
+from plugp100.common.functional.tri import Try
+from plugp100.components.light import LightComponent
 from plugp100.components.light_effect import LightEffectComponent
 from plugp100.devices.bulb import TapoBulb
 
@@ -168,7 +173,7 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
         elif hue_saturation is not None and ColorMode.HS in self.supported_color_modes:
             hue = int(hue_saturation[0])
             saturation = int(hue_saturation[1])
-            (await self.device.set_hue_saturation(hue, saturation)).get_or_raise()
+            (await self._set_hue_saturation(hue, saturation)).get_or_raise()
         elif (
             color_temp is not None
             and ColorMode.COLOR_TEMP in self.supported_color_modes
@@ -199,6 +204,19 @@ class TapoLightEntity(CoordinatedTapoEntity, LightEntity):
             ).get_or_raise()
         else:
             (await self.device.set_brightness(new_brightness)).get_or_raise()
+
+    async def _set_hue_saturation(self, hue: int, saturation: int) -> Try[bool]:
+        """Set HS while avoiding invalid payloads for near-white selections."""
+        if saturation > 0:
+            return await self.device.set_hue_saturation(hue, saturation)
+
+        light_component = self.device.get_component(LightComponent)
+        if light_component is None:
+            return await self.device.set_hue_saturation(hue, saturation)
+
+        return await light_component._client.set_device_info(
+            LightColorDeviceInfoParams(hue=hue, saturation=saturation)
+        )
 
 
 # follows https://developers.home-assistant.io/docs/core/entity/light/#color-modes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from homeassistant.setup import async_setup_component
 from plugp100.api.light_effect_preset import LightEffectPreset
 from plugp100.common.functional.tri import Success, Try
 from plugp100.components.energy import EnergyComponent
+from plugp100.components.light import LightComponent as PlugLightComponent
 from plugp100.components.light_effect import LightEffectComponent
 from plugp100.components.overheat import OverheatComponent
 from plugp100.devices.base import TapoDevice
@@ -32,11 +33,6 @@ pytest_plugins = ("pytest_homeassistant_custom_component",)
 class HS:
     hue: float
     saturation: float
-
-
-class LightComponent:
-    def __init__(self, *_args, **_kwargs) -> None:
-        pass
 
 
 class AlarmTypeList(list):
@@ -210,6 +206,10 @@ def mock_bulb(is_color: bool = True) -> MagicMock:
     device.set_light_effect = AsyncMock(return_value=Try.of(True))
     device.set_light_effect_brightness = AsyncMock(return_value=Try.of(True))
     device.__class__ = TapoBulb
+    light_component = MagicMock(PlugLightComponent(MagicMock()), name="Light component")
+    light_component.update = AsyncMock(return_value=None)
+    light_component._client.set_device_info = AsyncMock(return_value=Try.of(True))
+    device.add_component(light_component)
 
     return device
 
@@ -236,8 +236,9 @@ def mock_led_strip() -> MagicMock:
     device.set_light_effect_brightness = AsyncMock(return_value=Try.of(True))
     device.__class__ = TapoBulb
 
-    light_component = MagicMock(LightComponent(MagicMock()), name="Light component")
+    light_component = MagicMock(PlugLightComponent(MagicMock()), name="Light component")
     light_component.update = AsyncMock(return_value=None)
+    light_component._client.set_device_info = AsyncMock(return_value=Try.of(True))
     effect_component = MagicMock(
         LightEffectComponent(MagicMock()), name="Light effect component"
     )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -20,6 +20,10 @@ from homeassistant.components.light import (
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from plugp100.api.light_effect_preset import LightEffectPreset
+from plugp100.api.requests.set_device_info.set_light_color_info_params import (
+    LightColorDeviceInfoParams,
+)
+from plugp100.components.light import LightComponent
 import pytest
 
 from .conftest import extract_entity_id, mock_bulb, mock_led_strip, setup_platform
@@ -78,6 +82,20 @@ async def test_light_color_service_call(hass: HomeAssistant, tapo_device: MagicM
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (50, 10)},
         blocking=True,
+    )
+    tapo_device.set_hue_saturation.assert_called_with(50, 10)
+    light_component = tapo_device.get_component(LightComponent)
+    light_component._client.set_device_info.assert_not_called()
+    tapo_device.set_color_temperature.assert_not_called()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (50, 0)},
+        blocking=True,
+    )
+    light_component._client.set_device_info.assert_called_with(
+        LightColorDeviceInfoParams(hue=50, saturation=0)
     )
     tapo_device.set_hue_saturation.assert_called_with(50, 10)
     tapo_device.set_color_temperature.assert_not_called()
@@ -149,6 +167,8 @@ async def test_light_turn_on_with_attributes(
     )
     assert tapo_device.turn_on.called
     tapo_device.set_hue_saturation.assert_called_with(30, 10)
+    light_component = tapo_device.get_component(LightComponent)
+    light_component._client.set_device_info.assert_not_called()
     tapo_device.set_brightness.assert_called_with(12)
 
 


### PR DESCRIPTION
## Summary
- stop sending `color_temp=0` when applying HS colors to Tapo lights
- use the light component client directly for HS updates so the payload only contains hue and saturation
- extend light fixtures and tests to cover the new HS request path

Closes #783.

## Testing
- `python3 -m py_compile custom_components/tapo/light.py tests/conftest.py tests/test_light.py`
- `uv run pytest -q tests/test_light.py`
- `uv run pytest -q`
