### PR TITLE
fix: align config flow version with latest migration

### DIFF
--- a/custom_components/tapo/config_flow.py
+++ b/custom_components/tapo/config_flow.py
@@ -97,7 +97,7 @@ class FirstStepData:
 class TapoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for tapo."""
 
-    VERSION = 5
+    VERSION = 8
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self) -> None:


### PR DESCRIPTION
Fixes a mismatch between the config flow version and the latest migration version.

New entries were still created as version 5, while the integration expects version 8.