### PR TITLE
Fix H110 reload loop caused by internal AV child

### DIFF
--- a/custom_components/tapo/hub/hass_tapo_hub.py
+++ b/custom_components/tapo/hub/hass_tapo_hub.py
@@ -65,14 +65,38 @@ class HassTapoHub:
             device=self.hub,
         )
         # TODO: refactory with add_device and remove_device methods
-        initial_device_ids = list(map(lambda x: x.device_id, self.hub.children))
+        known_device_ids = {child.device_id for child in self.hub.children}
 
         async def _handle_child_device_event(event: HubDeviceEvent):
             _LOGGER.info("Detected child association change %s", str(event))
-            if event.device_id not in initial_device_ids:
+
+            if isinstance(event, DeviceAdded):
+                # H110 exposes internal IR/AV virtual children through the
+                # association stream. Their IDs are derived from the hub ID,
+                # but plugp100 does not expose them in hub.children.
+                if event.device_id.startswith(self.hub.device_id):
+                    _LOGGER.debug(
+                        "Ignoring internal H110 virtual child %s",
+                        event.device_id,
+                    )
+                    return
+
+                # The association subscription can replay DeviceAdded events for
+                # children that already existed when the subscription was created.
+                if event.device_id in known_device_ids:
+                    _LOGGER.debug(
+                        "Ignoring DeviceAdded for already known child %s",
+                        event.device_id,
+                    )
+                    return
+
+                known_device_ids.add(event.device_id)
                 await hass.config_entries.async_reload(self.entry.entry_id)
-            elif isinstance(event, DeviceAdded):
-                initial_device_ids.remove(event.device_id)
+                return
+
+            if event.device_id in known_device_ids:
+                known_device_ids.discard(event.device_id)
+                await hass.config_entries.async_reload(self.entry.entry_id)
 
         self.entry.async_on_unload(
             self.hub.subscribe_device_association(_handle_child_device_event)


### PR DESCRIPTION
## Summary

Fix an H110 initialization/reload loop caused by the hub association stream reporting an internal AV/IR virtual child as `DeviceAdded`.

The integration currently builds its initial child-device list from `self.hub.children`. On H110, the association stream can also emit an internal virtual AV/IR child whose ID is derived from the hub's own device ID. That virtual child is not present in `self.hub.children`, so the integration incorrectly treats it as a newly paired physical child and reloads the config entry.

This results in a repeated reload loop.

## Symptoms

On H110, this can cause:

- the integration to repeatedly flip between initializing and working
- repeated TPAP handshakes
- hub child devices becoming unavailable/reavailable
- repeated or ghost button events on devices such as S200B
- `RuntimeError: Session is closed` coordinator failures
- `Unclosed connection` errors

This appears to match the H110 behavior reported in #944.

## Root cause

With an H110 that has two real child devices, the integration reports:

`Found 2 children associated to hub ...`

However, the hub association stream emits three `DeviceAdded` events:

`DeviceAdded(real_child_1)`

`DeviceAdded(internal_AV_child)`

`DeviceAdded(real_child_2)`

The internal AV/IR child has an ID derived from the H110's own device ID. For example:

Hub:

`802DD0AB775B33878726208026AF0BFC2599D56B`

Virtual child:

`802DD0AB775B33878726208026AF0BFC2599D56B030B0001`

Because this virtual child is not present in `self.hub.children`, the existing callback considers it a newly added child and calls:

`await hass.config_entries.async_reload(self.entry.entry_id)`

The config entry reload recreates the H110 connection and association subscription, which causes the same virtual child event to be emitted again, creating an endless reload loop.

## Fix

The change:

- tracks known physical child IDs as a set
- ignores replayed `DeviceAdded` events for already-known physical children
- ignores H110 internal virtual children whose device ID is derived from the hub's own device ID
- reloads the config entry only when a genuinely new physical child is added or an existing physical child is removed

This preserves normal child-device discovery while preventing H110 internal AV/IR devices from triggering a reload.

## Testing

Tested on a TP-Link Tapo H110 with an S200B button.

### Before the fix

- H110 reinitialized every few seconds
- repeated TPAP handshakes occurred
- S200B entities repeatedly became unavailable and available
- button events could be replayed
- coordinator logs showed `RuntimeError: Session is closed`
- Home Assistant also logged unclosed connection errors

### After the fix

- H110 remains initialized
- coordinator polling remains stable
- repeated TPAP handshakes stop
- config-entry reload loop stops
- S200B remains available
- button automation triggers correctly once per physical press
- `Session is closed` errors no longer occur

Relates to #944.