### PR TITLE
fix(migration): fail v8 migration gracefully when the device is offline

### DIFF
--- a/custom_components/tapo/__init__.py
+++ b/custom_components/tapo/__init__.py
@@ -86,7 +86,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version != 8:
-        await migrate_entry_to_v8(hass, config_entry)
+        if not await migrate_entry_to_v8(hass, config_entry):
+            return False
         _LOGGER.info("Migration to version %s successful", config_entry.version)
 
     return True

--- a/custom_components/tapo/migrations.py
+++ b/custom_components/tapo/migrations.py
@@ -1,20 +1,45 @@
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from plugp100.devices import connect
+from plugp100.errors.protocol_guess import (
+    HostUnreachableError,
+    ProtocolDetectionTimeoutError,
+)
 
-from custom_components.tapo.const import CONF_MAC, DEFAULT_POLLING_RATE_S
+from custom_components.tapo.const import CONF_HOST, CONF_MAC, DEFAULT_POLLING_RATE_S
 from custom_components.tapo.setup_helpers import (
     create_aiohttp_session,
     create_device_config,
 )
 
+_LOGGER = logging.getLogger(__name__)
 
-async def migrate_entry_to_v8(hass: HomeAssistant, config_entry: ConfigEntry):
+
+async def migrate_entry_to_v8(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     session = create_aiohttp_session(hass)
-    device = await connect(config=create_device_config(config_entry), session=session)
-    await device.update()
+    try:
+        device = await connect(config=create_device_config(config_entry), session=session)
+        await device.update()
+    except (HostUnreachableError, ProtocolDetectionTimeoutError) as error:
+        # The v8 migration needs to reach the device only to read its MAC. If the
+        # device is offline while Home Assistant starts, don't let the exception
+        # bubble up (that produces a scary traceback and marks the entry as
+        # permanently failed). Fail the migration cleanly instead; Home Assistant
+        # retries it on the next restart, when the device is reachable again.
+        _LOGGER.error(
+            "Cannot migrate Tapo entry '%s' from version %s: device at %s is "
+            "unreachable (%s). Migration will be retried on the next restart.",
+            config_entry.title,
+            config_entry.version,
+            config_entry.data.get(CONF_HOST),
+            error,
+        )
+        return False
+
     new_data = {**config_entry.data}
     scan_interval = new_data.pop(CONF_SCAN_INTERVAL, DEFAULT_POLLING_RATE_S)
     if mac := device.mac:
@@ -27,5 +52,13 @@ async def migrate_entry_to_v8(hass: HomeAssistant, config_entry: ConfigEntry):
             },
             version=8,
         )
-    else:
-        raise Exception("Failed to fetch data to migrate entity")
+        return True
+
+    _LOGGER.error(
+        "Cannot migrate Tapo entry '%s' from version %s: device at %s did not "
+        "report a MAC address. Migration will be retried on the next restart.",
+        config_entry.title,
+        config_entry.version,
+        config_entry.data.get(CONF_HOST),
+    )
+    return False


### PR DESCRIPTION
## Problem

When a config entry is migrated to v8 while the physical device is offline, Home Assistant logs a full traceback and the entry is left permanently failed (`MIGRATION_ERROR`) until the next restart:

```
ERROR (MainThread) [homeassistant.config_entries] Error migrating entry LumeCamera for tapo
Traceback (most recent call last):
  ...
  File "/config/custom_components/tapo/migrations.py", line 16, in migrate_entry_to_v8
    device = await connect(config=create_device_config(config_entry), session=session)
  ...
plugp100.errors.protocol_guess.HostUnreachableError: Unable to reach device for 192.168.50.68
```

`migrate_entry_to_v8` connects to the device **only to read its MAC**. If the device is unreachable at startup (device booting after HA, DHCP lease change, temporary network issue), `connect()` raises `HostUnreachableError` / `ProtocolDetectionTimeoutError`, the exception bubbles out of `async_migrate_entry`, and `config_entries.async_migrate` catches it with a blanket `except Exception: logger.exception(...)` — hence the traceback — and returns `False`.

## Change

- Catch the connectivity errors (`HostUnreachableError`, `ProtocolDetectionTimeoutError`) in `migrate_entry_to_v8`, log a clear `ERROR` line naming the entry, the source version and the host, and `return False` so the migration fails cleanly (no traceback). HA retries the migration on the next restart, when the device is reachable again.
- The "no MAC reported" branch now also logs a clear message and returns `False` instead of raising a bare `Exception`.
- `async_migrate_entry` propagates the `False` from `migrate_entry_to_v8` instead of always returning `True`.

`ERROR` level is intentional: the migration genuinely failed and the entry did not load, matching the severity of the previous (traceback) behaviour, and it stays visible under logger configs that set `default: error`.

## Testing

Verified on a live install: with the Tapo device offline at startup, the migration no longer produces a traceback — only the single `ERROR` line is emitted — and the entry migrates normally once the device is back online and HA is restarted.